### PR TITLE
Ct 1344 downloaded status

### DIFF
--- a/src/_actions/files.js
+++ b/src/_actions/files.js
@@ -63,6 +63,11 @@ const rename = file => {
   fs.renameSync(existingPath, file.fullPath);
 };
 
+/**
+ * Set the downloaded state of the task entity on the web app.
+ * @param {string} jobLabel
+ * @param {string} downloadId
+ */
 export function reportDownloadedState(jobLabel, downloadId) {
   return async function(dispatch, getState) {
     const state = getState();
@@ -81,6 +86,20 @@ export function reportDownloadedState(jobLabel, downloadId) {
     }
   };
 }
+
+/**
+ * Determine if this file is to be downloded. This function is given as a filter
+ * while adding files to the queue and is responsible for only adding files that
+ * should be downloaded.
+ *
+ * If the file already exists, we don't want to add it. And if we can't prepare
+ * a directory, then we dont want to add it either.
+ *
+ * @param {*} file The object representing a file that may be added to the
+ * queue.
+ * @param {*} callback A callback to run with an error message or the file.
+ * @returns The result of the callback.
+ */
 
 const canAndShouldDownload = (file, callback) => {
   if (exactFileExistsSync(file.fullPath, file.md5)) {

--- a/src/_actions/files.js
+++ b/src/_actions/files.js
@@ -133,7 +133,7 @@ const canAndShouldDownload = (file, callback) => {
  *    until it has failed (maxRetries+1) times.
  * */
 const queueOptions = {
-  concurrent: 4,
+  concurrent: 8,
   setImmediate: fn => {
     setTimeout(fn, 0);
   },

--- a/src/_actions/files.js
+++ b/src/_actions/files.js
@@ -38,10 +38,6 @@ export const receiveExistingFilesInfo = createAction(
 
 export const setFileExists = createAction("downloader/setFileExists");
 
-// export const incrementTaskDownloads = createAction(
-//   "downloader/incrementTaskDownloads"
-// );
-
 const Queue = require("better-queue");
 const MemoryStore = require("better-queue-memory");
 

--- a/src/_actions/files.js
+++ b/src/_actions/files.js
@@ -74,7 +74,6 @@ export function reportDownloadedState(jobLabel, downloadId) {
     const task = state.entities.jobs[jobLabel].tasks[downloadId];
     if (task.downloaded === task.files) {
       const options = createRequestOptions(tokenSelector(state));
-
       const url = `${config.projectUrl}/downloads/status`;
       const data = {
         download_id: downloadId,

--- a/src/_reducers/entities/jobs.js
+++ b/src/_reducers/entities/jobs.js
@@ -3,14 +3,14 @@ import { createReducer } from "@reduxjs/toolkit";
 import {
   receiveJobs,
   setOutputPathValue,
-  resetOutputPathValue
+  resetOutputPathValue,
 } from "../../_actions/jobs";
 
 import {
   receiveDownloadData,
   receiveExistingFilesInfo,
   setFileExists,
-  requestDownloadData
+  requestDownloadData,
 } from "../../_actions/files";
 
 import os from "os";
@@ -18,7 +18,7 @@ import os from "os";
 export const LOADING_KEYS = {
   NONE: 0,
   DOWNLOAD_DETAILS: 1,
-  EXISTING_FILES: 2
+  EXISTING_FILES: 2,
 };
 
 const PLATFORM = os.platform();
@@ -65,7 +65,7 @@ const jobs = createReducer(initialState, {
         outputDirectory:
           (state[jobLabel] && state[jobLabel].outputDirectory) ||
           outputDirectory,
-        owner: job.owner || job.user || "anon"
+        owner: job.owner || job.user || "anon",
       };
 
       state[jobLabel] = jobSummary;
@@ -73,12 +73,14 @@ const jobs = createReducer(initialState, {
   },
 
   [receiveDownloadData]: (state, action) => {
-    const { files, jobLabel } = action.payload;
+    const { downloadData, jobLabel } = action.payload;
 
     if (jobLabel in state) {
+      const { files, tasks } = downloadData;
       Object.assign(state[jobLabel], {
         files,
-        loadingKey: LOADING_KEYS.NONE
+        tasks,
+        loadingKey: LOADING_KEYS.NONE,
       });
     }
   },
@@ -132,7 +134,7 @@ const jobs = createReducer(initialState, {
     if (jobLabel in state) {
       state[jobLabel].outputDirectory = state[jobLabel].originalOutputDirectory;
     }
-  }
+  },
 });
 
 export default jobs;

--- a/src/_reducers/entities/jobs.js
+++ b/src/_reducers/entities/jobs.js
@@ -3,14 +3,14 @@ import { createReducer } from "@reduxjs/toolkit";
 import {
   receiveJobs,
   setOutputPathValue,
-  resetOutputPathValue,
+  resetOutputPathValue
 } from "../../_actions/jobs";
 
 import {
   receiveDownloadData,
   receiveExistingFilesInfo,
   setFileExists,
-  requestDownloadData,
+  requestDownloadData
 } from "../../_actions/files";
 
 import os from "os";
@@ -18,7 +18,7 @@ import os from "os";
 export const LOADING_KEYS = {
   NONE: 0,
   DOWNLOAD_DETAILS: 1,
-  EXISTING_FILES: 2,
+  EXISTING_FILES: 2
 };
 
 const PLATFORM = os.platform();
@@ -65,7 +65,7 @@ const jobs = createReducer(initialState, {
         outputDirectory:
           (state[jobLabel] && state[jobLabel].outputDirectory) ||
           outputDirectory,
-        owner: job.owner || job.user || "anon",
+        owner: job.owner || job.user || "anon"
       };
 
       state[jobLabel] = jobSummary;
@@ -80,7 +80,7 @@ const jobs = createReducer(initialState, {
       Object.assign(state[jobLabel], {
         files,
         tasks,
-        loadingKey: LOADING_KEYS.NONE,
+        loadingKey: LOADING_KEYS.NONE
       });
     }
   },
@@ -111,9 +111,14 @@ const jobs = createReducer(initialState, {
   },
 
   [setFileExists]: (state, action) => {
-    const { jobLabel, relativePath, percentage } = action.payload;
+    const { jobLabel, relativePath, percentage, downloadId } = action.payload;
+
     if (jobLabel in state && relativePath in state[jobLabel].files) {
       state[jobLabel].files[relativePath].exists = percentage;
+    }
+    if (downloadId !== undefined) {
+      /** downloadId is provided only when a file successfully completes */
+      state[jobLabel].tasks[downloadId].downloaded += 1;
     }
   },
 
@@ -134,7 +139,7 @@ const jobs = createReducer(initialState, {
     if (jobLabel in state) {
       state[jobLabel].outputDirectory = state[jobLabel].originalOutputDirectory;
     }
-  },
+  }
 });
 
 export default jobs;


### PR DESCRIPTION
Adds functionality to post to the web app when all files in a task are downloaded.

There was previously no concept of tasks in the redux state. Files are direct children of a job. It would be a pain to restructure files, so a `tasks` property is added as a sibling of files (under the job), and its only purpose is to track the number of files that have completed for that task. When the file complete event is emitted:-

- Update the file percentage done (as before)
- Increment the downloaded property of the task.
- If all files for a task are downloaded, post an update.

No partially downloaded data, such as bytesReceived, is sent at this time. 